### PR TITLE
ROS RGBD use g2o_modified to solved ROS RGBD example segment fault problem

### DIFF
--- a/ORB_SLAM2_modified/Examples/ROS/ORB_SLAM2/CMakeLists.txt
+++ b/ORB_SLAM2_modified/Examples/ROS/ORB_SLAM2/CMakeLists.txt
@@ -43,6 +43,7 @@ endif()
 
 find_package(Eigen3 3.1.0 REQUIRED)
 find_package(Pangolin REQUIRED)
+find_package(G2O REQUIRED)
 
 include_directories(
 ${PROJECT_SOURCE_DIR}
@@ -56,13 +57,7 @@ ${OpenCV_LIBS}
 ${EIGEN3_LIBS}
 ${Pangolin_LIBRARIES}
 ${PROJECT_SOURCE_DIR}/../../../Thirdparty/DBoW2/lib/libDBoW2.so
-${PROJECT_SOURCE_DIR}/../../../../g2o_with_orbslam2/lib/libg2o_core.so
-${PROJECT_SOURCE_DIR}/../../../../g2o_with_orbslam2/lib/libg2o_types_sclam2d.so
-${PROJECT_SOURCE_DIR}/../../../../g2o_with_orbslam2/lib/libg2o_solver_csparse.so
-${PROJECT_SOURCE_DIR}/../../../../g2o_with_orbslam2/lib/libg2o_stuff.so
-${PROJECT_SOURCE_DIR}/../../../../g2o_with_orbslam2/lib/libg2o_csparse_extension.so
-${PROJECT_SOURCE_DIR}/../../../../g2o_with_orbslam2/lib/libg2o_types_sim3.so
-${PROJECT_SOURCE_DIR}/../../../../g2o_with_orbslam2/lib/libg2o_types_sba.so
+g2o_core g2o_types_slam3d g2o_solver_csparse g2o_stuff g2o_csparse_extension g2o_types_sim3 g2o_types_sba
 ${PROJECT_SOURCE_DIR}/../../../lib/libORB_SLAM2.so
 )
 

--- a/ORB_SLAM2_modified/Examples/ROS/ORB_SLAM2/CMakeLists.txt
+++ b/ORB_SLAM2_modified/Examples/ROS/ORB_SLAM2/CMakeLists.txt
@@ -56,7 +56,13 @@ ${OpenCV_LIBS}
 ${EIGEN3_LIBS}
 ${Pangolin_LIBRARIES}
 ${PROJECT_SOURCE_DIR}/../../../Thirdparty/DBoW2/lib/libDBoW2.so
-${PROJECT_SOURCE_DIR}/../../../Thirdparty/g2o/lib/libg2o.so
+${PROJECT_SOURCE_DIR}/../../../../g2o_with_orbslam2/lib/libg2o_core.so
+${PROJECT_SOURCE_DIR}/../../../../g2o_with_orbslam2/lib/libg2o_types_sclam2d.so
+${PROJECT_SOURCE_DIR}/../../../../g2o_with_orbslam2/lib/libg2o_solver_csparse.so
+${PROJECT_SOURCE_DIR}/../../../../g2o_with_orbslam2/lib/libg2o_stuff.so
+${PROJECT_SOURCE_DIR}/../../../../g2o_with_orbslam2/lib/libg2o_csparse_extension.so
+${PROJECT_SOURCE_DIR}/../../../../g2o_with_orbslam2/lib/libg2o_types_sim3.so
+${PROJECT_SOURCE_DIR}/../../../../g2o_with_orbslam2/lib/libg2o_types_sba.so
 ${PROJECT_SOURCE_DIR}/../../../lib/libORB_SLAM2.so
 )
 


### PR DESCRIPTION
Because ROS example in orb_slam2_modified used original third party g2o,it could casue segment  #27 .
Hence this pull request use g2o_modified in cmake.
I test this modified by myself and it is totally work well. 